### PR TITLE
Step 4: Migrate One AngularJS Component to Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ This project documents the step-by-step process of migrating an AngularJS applic
 
 ---
 
+### Step 4: Migrate One AngularJS Component to Angular
+#### What We Did:
+- Created an Angular `ItemListComponent` to replace the AngularJS list component.
+- Used `downgradeComponent` to make the Angular component usable in AngularJS templates.
+- Resolved conflicts in hybrid bootstrapping.
+
+#### Importance:
+- Demonstrates a successful component migration while maintaining hybrid functionality.
+- Shows how to use Angular components in AngularJS templates, paving the way for further migration
+
+#### Alignment with Migration Guides:
+- Reflects the "Upgrade AngularJS Components" step, focusing on migrating components incrementally.
+
+---
+
 ## How This Aligns with the Bigger Picture
 
 ### Incremental Migration:
@@ -71,20 +86,9 @@ This project documents the step-by-step process of migrating an AngularJS applic
 1. Set up the AngularJS app.
 2. Set up the Angular project.
 3. Configured hybrid integration.
+4. Migrated one AngularJS component to Angular.
 
 ### Remaining:
-1. Migrate AngularJS components to Angular.
-2. Migrate AngularJS services to Angular.
-3. Finalize migration by removing AngularJS dependencies and testing.
+1. Migrate AngularJS services to Angular.
+2. Finalize migration by removing AngularJS dependencies and testing.
 
----
-
-## Bigger Picture
-This process aligns with:
-- **PhoneCat Upgrade Tutorial**
-- **Official Angular Migration Guide**
-
-### Focus Areas:
-1. Preparing a strong base.
-2. Creating a hybrid app for safe migration.
-3. Gradually migrating components and services without disrupting functionality.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# AngularJS to Angular Migration
+
+## Overview
+This project documents the step-by-step process of migrating an AngularJS application to Angular, leveraging a hybrid approach. By setting up a hybrid environment, we enable progressive migration, ensuring functionality is preserved throughout the process.
+
+---
+
+## Steps Completed
+
+### Step 1: Set Up the AngularJS App
+#### What We Did:
+- Created a basic AngularJS app (`pocApp`) with a simple list and detail view.
+- Defined the AngularJS module and controller in `app.js`.
+- Verified functionality in a standalone AngularJS setup.
+
+#### Importance:
+- Established the foundation for the migration process.
+- Ensured there is a working AngularJS app to progressively migrate to Angular.
+
+#### Alignment with Migration Guides:
+- Matches the initial step in the PhoneCat tutorial to prepare the AngularJS application as the starting point for migration.
+
+---
+
+### Step 2: Set Up the Angular Project
+#### What We Did:
+- Created a new Angular project using Angular CLI.
+- Installed the `@angular/upgrade` package to enable hybrid integration.
+- Organized the project structure for seamless integration.
+
+#### Importance:
+- Set up the Angular environment to serve as the migration target.
+- Prepared the app for the hybrid approach, where AngularJS and Angular coexist.
+
+#### Alignment with Migration Guides:
+- Mirrors the step where the Angular workspace is created to integrate with the existing AngularJS application.
+
+---
+
+### Step 3: Hybrid Integration (AngularJS + Angular)
+#### What We Did:
+- Updated `main.ts` to bootstrap both Angular and AngularJS using `UpgradeModule`.
+- Linked AngularJS (`angular.min.js`) and `app.js` in `index.html`.
+- Resolved issues related to file loading, static file serving, and module initialization.
+
+#### Importance:
+- Enabled AngularJS and Angular to run together in the same application.
+- Formed the core of the hybrid approach, allowing progressive migration without breaking functionality.
+
+#### Alignment with Migration Guides:
+- Matches the "Bootstrapping a Hybrid Application" section by configuring `UpgradeModule` for dual-framework operation.
+
+---
+
+## How This Aligns with the Bigger Picture
+
+### Incremental Migration:
+- The hybrid environment enables the migration of components and services one step at a time, avoiding the risk of breaking the app by migrating everything at once.
+
+### Progressive Replacement:
+- Components and services are gradually replaced with Angular versions, ensuring functionality is preserved throughout the migration.
+
+### Hybrid Approach Benefits:
+- Allows developers to test Angular features in a controlled environment while still relying on existing AngularJS components.
+
+---
+
+## Steps Completed vs. Remaining
+
+### Completed:
+1. Set up the AngularJS app.
+2. Set up the Angular project.
+3. Configured hybrid integration.
+
+### Remaining:
+1. Migrate AngularJS components to Angular.
+2. Migrate AngularJS services to Angular.
+3. Finalize migration by removing AngularJS dependencies and testing.
+
+---
+
+## Bigger Picture
+This process aligns with:
+- **PhoneCat Upgrade Tutorial**
+- **Official Angular Migration Guide**
+
+### Focus Areas:
+1. Preparing a strong base.
+2. Creating a hybrid app for safe migration.
+3. Gradually migrating components and services without disrupting functionality.

--- a/angular-app/src/app/app.component.ts
+++ b/angular-app/src/app/app.component.ts
@@ -3,10 +3,10 @@ import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   imports: [RouterOutlet],
   template: `
     <h1>Welcome to {{title}}!</h1>
-
     <router-outlet />
   `,
   styles: [],

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -1,12 +1,25 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { UpgradeModule } from '@angular/upgrade/static';
-import { AppComponent } from './app.component'; // Use it directly.
+import { downgradeComponent } from '@angular/upgrade/static';
+import { ItemListComponent } from './item-list/item-list.component';
+
+declare var angular: any;
 
 @NgModule({
-  imports: [BrowserModule, UpgradeModule, AppComponent], // Import it directly
-  bootstrap: [AppComponent],
+  imports: [BrowserModule, UpgradeModule],
+  declarations: [],
 })
 export class AppModule {
-  constructor(upgrade: UpgradeModule) {}
+  constructor(private upgrade: UpgradeModule) {}
+
+  ngDoBootstrap() {
+    // Bootstrap AngularJS application
+    this.upgrade.bootstrap(document.body, ['pocApp'], { strictDi: true });
+  }
 }
+
+// Downgrade Angular component for AngularJS
+angular.module('pocApp').directive('appItemList', downgradeComponent({
+  component: ItemListComponent,
+}));

--- a/angular-app/src/app/item-list/item-list.component.html
+++ b/angular-app/src/app/item-list/item-list.component.html
@@ -1,0 +1,4 @@
+<h1>Items</h1>
+<ul>
+  <li *ngFor="let item of items">{{ item }}</li>
+</ul>

--- a/angular-app/src/app/item-list/item-list.component.ts
+++ b/angular-app/src/app/item-list/item-list.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'app-item-list',
+  templateUrl: './item-list.component.html',
+  styleUrls: ['./item-list.component.css'],
+  imports: [CommonModule],
+})
+export class ItemListComponent {
+  items = ['Item 1', 'Item 2', 'Item 3'];
+}

--- a/angular-app/src/assets/app.js
+++ b/angular-app/src/assets/app.js
@@ -1,4 +1,6 @@
 var app = angular.module('pocApp', []);
+console.log('AngularJS module pocApp loaded:', app);
+
 app.controller('ListController', function ($scope) {
     $scope.items = ['Item 1', 'Item 2', 'Item 3'];
 });

--- a/angular-app/src/index.html
+++ b/angular-app/src/index.html
@@ -6,10 +6,12 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.9/angular.min.js"></script>
+  <script src="assets/app.js"></script>
 </head>
 <body>
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.9/angular.min.js"></script> <!-- Use CDN -->
-  <script src="assets/app.js"></script>
-  <app-root></app-root>
+  <app-root>
+    <app-item-list></app-item-list>
+  </app-root>
 </body>
 </html>

--- a/angular-app/src/main.ts
+++ b/angular-app/src/main.ts
@@ -1,16 +1,6 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AppModule } from './app/app.module';
-import angular from 'angular';
-
-// Import AngularJS module (adjust the path)
-//import '../assets/app.js';
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
-  .then((platformRef) => {
-    // Bootstrap AngularJS
-    const upgrade = platformRef.injector.get(UpgradeModule);
-    upgrade.bootstrap(document.body, ['pocApp'], { strictDi: true });
-  })
   .catch((err) => console.error(err));


### PR DESCRIPTION
### What We Did:

- Created an Angular ItemListComponent to replace the AngularJS list component.
- Used downgradeComponent to make the Angular component usable in AngularJS templates.
- Resolved conflicts in hybrid bootstrapping.
